### PR TITLE
Strip binaries and disable not used functionality

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -20,7 +20,7 @@ TARG_XTRA_OPTS=""
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
 ## Configure the build.
 ../configure \
@@ -28,10 +28,11 @@ mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
   --prefix="$PS2DEV/$TARGET_ALIAS" \
   --target="$TARGET" \
   --disable-lto \
+  --disable-sim \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
 make --quiet -j $PROC_NR clean   || { exit 1; }
 make --quiet -j $PROC_NR CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0" || { exit 1; }
-make --quiet -j $PROC_NR install || { exit 1; }
+make --quiet -j $PROC_NR install-strip || { exit 1; }
 make --quiet -j $PROC_NR clean   || { exit 1; }

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -28,6 +28,8 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
   --prefix="$PS2DEV/$TARGET_ALIAS" \
   --target="$TARGET" \
   --disable-lto \
+  --disable-nls \
+  --disable-separate-code \
   --disable-sim \
   $TARG_XTRA_OPTS || { exit 1; }
 

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -35,23 +35,26 @@ rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TAR
   --target="$TARGET" \
   --enable-languages="c" \
   --with-float=hard \
-  --with-newlib \
-  --disable-nls \
-  --disable-shared \
-  --disable-libssp \
-  --disable-libmudflap \
-  --disable-threads \
-  --disable-libgomp \
-  --disable-libquadmath \
-  --disable-target-libiberty \
-  --disable-target-zlib \
-  --without-ppl \
-  --without-cloog \
   --with-headers=no \
+  --without-newlib \
+  --without-cloog \
+  --without-ppl \
+  --disable-decimal-float \
   --disable-libada \
   --disable-libatomic \
-  --disable-multilib \
+  --disable-libffi \
+  --disable-libgomp \
+  --disable-libmudflap \
+  --disable-libquadmath \
+  --disable-libssp \
+  --disable-libstdcxx-pch \
   --disable-lto \
+  --disable-multilib \
+  --disable-nls \
+  --disable-shared \
+  --disable-threads \
+  --disable-target-libiberty \
+  --disable-target-zlib \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -26,7 +26,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
+rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
 
 ## Configure the build.
 ../configure \
@@ -55,7 +55,7 @@ mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean   || { exit 1; }
-make --quiet -j $PROC_NR all     || { exit 1; }
-make --quiet -j $PROC_NR install || { exit 1; }
-make --quiet -j $PROC_NR clean   || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -18,10 +18,13 @@ TARGET="mips64r5900el-ps2-elf"
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
 ## Configure the build.
 CFLAGS_FOR_TARGET="-G0" ../configure --prefix="$PS2DEV/$TARGET_ALIAS" --target="$TARGET" || { exit 1; }
 
 ## Compile and install.
-make clean && make -j $PROC_NR && make install && make clean || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/004-gcc-stage2.sh
+++ b/scripts/004-gcc-stage2.sh
@@ -26,7 +26,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
+rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
 
 ## Configure the build.
 ../configure \
@@ -55,7 +55,7 @@ mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean   || { exit 1; }
-make --quiet -j $PROC_NR all     || { exit 1; }
-make --quiet -j $PROC_NR install || { exit 1; }
-make --quiet -j $PROC_NR clean   || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/004-gcc-stage2.sh
+++ b/scripts/004-gcc-stage2.sh
@@ -35,23 +35,26 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --target="$TARGET" \
   --enable-languages="c,c++" \
   --with-float=hard \
-  --with-newlib \
-  --disable-nls \
-  --disable-shared \
-  --disable-libssp \
-  --disable-libmudflap \
-  --disable-threads \
-  --disable-libgomp \
-  --disable-libquadmath \
-  --disable-target-libiberty \
-  --disable-target-zlib \
-  --without-ppl \
-  --without-cloog \
   --with-headers="$PS2DEV/$TARGET_ALIAS/$TARGET/include" \
+  --with-newlib \
+  --without-cloog \
+  --without-ppl \
+  --disable-decimal-float \
   --disable-libada \
   --disable-libatomic \
-  --disable-multilib \
+  --disable-libffi \
+  --disable-libgomp \
+  --disable-libmudflap \
+  --disable-libquadmath \
+  --disable-libssp \
+  --disable-libstdcxx-pch \
   --disable-lto \
+  --disable-multilib \
+  --disable-nls \
+  --disable-shared \
+  --disable-threads \
+  --disable-target-libiberty \
+  --disable-target-zlib \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
## Description
This PR strips all binaries generated during `BinUtils`, `GCC` and `NewLib`
Additionally, it disables a bunch of utils that are not useful for the current status of the `PS2Dev`.

Thanks