### PR TITLE
Add -O2 to the newlib compilation

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -21,7 +21,7 @@ PROC_NR=$(getconf _NPROCESSORS_ONLN)
 rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
 ## Configure the build.
-CFLAGS_FOR_TARGET="-G0" ../configure --prefix="$PS2DEV/$TARGET_ALIAS" --target="$TARGET" || { exit 1; }
+CFLAGS_FOR_TARGET="-G0 -O2" ../configure --prefix="$PS2DEV/$TARGET_ALIAS" --target="$TARGET" || { exit 1; }
 
 ## Compile and install.
 make --quiet -j $PROC_NR clean          || { exit 1; }


### PR DESCRIPTION
How the `CFLAGS_FOR_TARGET` was overridden, the `-O2` flag was missing in the newlib compilation, making it "less optimal", is quite important to have a good performance for libc's operation.

Thanks