### PR TITLE
Increase to GCC 11.1.0 and generate newlib-nano

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -4,7 +4,7 @@
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/gcc.git"
 REPO_FOLDER="gcc"
-BRANCH_NAME="ee-v10.2.0"
+BRANCH_NAME="ee-v11.1.0"
 if test ! -d "$REPO_FOLDER"; then
 	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || exit 1
 else

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# 004-newlib-nano.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## This script is needed to generate a separate and nano libc. This is usefull for such programs that requires to have tiny binaries.
+## I have tried to use --program-suffix during configure, but it looks that newlib is not using the flag properly.
+## For this reason it requires to use a custom instalation script
+
+## Download the source code.
+REPO_URL="https://github.com/ps2dev/newlib.git"
+REPO_FOLDER="newlib"
+BRANCH_NAME="ee-v4.1.0"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || exit 1
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || exit 1
+fi
+
+TARGET_ALIAS="ee" 
+TARGET="mips64r5900el-ps2-elf"
+TARG_XTRA_OPTS=""
+OSVER=$(uname)
+
+## Apple needs to pretend to be linux
+if [ ${OSVER:0:10} == MINGW64_NT ]; then
+	export lt_cv_sys_max_cmd_len=8000
+	export CC=x86_64-w64-mingw32-gcc
+	TARG_XTRA_OPTS="--host=x86_64-w64-mingw32"
+elif [ ${OSVER:0:10} == MINGW32_NT ]; then
+	export lt_cv_sys_max_cmd_len=8000
+	export CC=i686-w64-mingw32-gcc
+	TARG_XTRA_OPTS="--host=i686-w64-mingw32"
+fi
+
+PS2DEV_TMP=$PWD/ps2dev-tmp
+
+## Create ps2dev-tmp folder
+rm -rf $PS2DEV_TMP && mkdir $PS2DEV_TMP || { exit 1; }
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## Create and enter the toolchain/build directory
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+
+## Configure the build.
+CFLAGS_FOR_TARGET="-DPREFER_SIZE_OVER_SPEED=1 -G0 -Os" ../configure \
+	--target="$TARGET" \
+	--prefix="$PS2DEV_TMP/$TARGET_ALIAS" \
+	--disable-newlib-supplied-syscalls \
+	--enable-newlib-reent-small \
+	--disable-newlib-fvwrite-in-streamio \
+	--disable-newlib-fseek-optimization \
+	--disable-newlib-wide-orient \
+	--enable-newlib-nano-malloc \
+	--disable-newlib-unbuf-stream-opt \
+	--enable-lite-exit \
+	--enable-newlib-global-atexit \
+	--enable-newlib-nano-formatted-io \
+	--disable-nls \
+	$TARG_XTRA_OPTS || { exit 1; }
+
+
+## Compile and install.
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }
+
+## Copy & rename manually libc, libg and libm to libc-nano, libg-nano and libm-nano
+mv $PS2DEV_TMP/$TARGET_ALIAS/$TARGET/lib/libc.a $PS2DEV/$TARGET_ALIAS/$TARGET/lib/libc_nano.a
+mv $PS2DEV_TMP/$TARGET_ALIAS/$TARGET/lib/libg.a $PS2DEV/$TARGET_ALIAS/$TARGET/lib/libg_nano.a
+mv $PS2DEV_TMP/$TARGET_ALIAS/$TARGET/lib/libm.a $PS2DEV/$TARGET_ALIAS/$TARGET/lib/libm_nano.a

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 004-gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 005-gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
 
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/gcc.git"

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -4,7 +4,7 @@
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/gcc.git"
 REPO_FOLDER="gcc"
-BRANCH_NAME="ee-v10.2.0"
+BRANCH_NAME="ee-v11.1.0"
 if test ! -d "$REPO_FOLDER"; then
 	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || exit 1
 else


### PR DESCRIPTION
## Description

This PR makes basically 2 things:
1. Update GCC version from `10.2.0` to `11.1.10`
2. Add one more extra step for generating a nano version of newlib (`libc_nano.a` and `libm_nano.a`). This could be useful for apps that really cares about binary sizes.

Thanks