### PR TITLE
Build GCC without TLS support

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -56,6 +56,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --without-newlib \
     --disable-libssp \
     --disable-multilib \
+    --disable-tls \
     $TARG_XTRA_OPTS
 
   ## Compile and install.

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -57,6 +57,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-libssp \
     --disable-multilib \
     --enable-cxx-flags=-G0 \
+    --disable-tls \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
For thread local storage GCC emits RWHDR instructions to get the TLS area. The encoding of this instruction clashes with the EE's SQ instruction.

Since we don't support TLS anyway, we should build with `--disable-tls`



references
https://patchwork.kernel.org/project/linux-mips/patch/4f856a5ea2c039c6639df875d11b5bff1bf7ecd2.1567326213.git.noring@nocrew.org/