### PR TITLE
Adding support for `pthread` and `std::thread`

### DIFF
--- a/scripts/005-pthread-embedded.sh
+++ b/scripts/005-pthread-embedded.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# pthread-embedded.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Exit with code 1 when any command executed returns a non-zero exit code.
+onerr()
+{
+  exit 1;
+}
+trap onerr ERR
+
+## Download the source code.
+REPO_URL="https://github.com/ps2dev/pthread-embedded.git"
+REPO_FOLDER="pthread-embedded"
+BRANCH_NAME="platform_agnostic"
+if test ! -d "$REPO_FOLDER"; then
+  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
+else
+  git -C "$REPO_FOLDER" fetch origin
+  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
+  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+fi
+cd "$REPO_FOLDER"
+
+TARGET_ALIAS="ee"
+TARG_XTRA_OPTS=""
+OSVER=$(uname)
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## For each target...
+for TARGET in "mips64r5900el-ps2-elf"; do
+  cd platform/ps2 || { exit 1; }
+
+  ## Compile and install.
+  make --quiet -j "$PROC_NR" all
+  make --quiet -j "$PROC_NR" install
+  make --quiet -j "$PROC_NR" clean
+
+  ## Exit the build directory.
+  cd ../..
+
+  ## End target.
+done

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 005-gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 006-gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -52,12 +52,13 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --target="$TARGET" \
     --enable-languages="c,c++" \
     --with-float=hard \
-    --with-headers="$PS2DEV/$TARGET_ALIAS/$TARGET/include" \
+    --with-sysroot="$PS2DEV/$TARGET_ALIAS/$TARGET" \
     --with-newlib \
     --disable-libssp \
     --disable-multilib \
-    --enable-cxx-flags=-G0 \
     --disable-tls \
+    --enable-cxx-flags=-G0 \
+    --enable-threads=posix \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
This PR is part of a collection for the std::tread support in the PS2 EE Toolchain

It basically does:

Add pthread-embedded to the compilation scripts.

This PR requires https://github.com/ps2dev/gcc/pull/2 to be merged first, otherwise it won't compile.