### PR TITLE
Pointing to newlib 4.3.0

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -11,7 +11,7 @@ trap onerr ERR
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/newlib.git"
 REPO_FOLDER="newlib"
-BRANCH_NAME="ee-v4.1.0"
+BRANCH_NAME="ee-v4.3.0"
 if test ! -d "$REPO_FOLDER"; then
   git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
 else

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -15,7 +15,7 @@ trap onerr ERR
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/newlib.git"
 REPO_FOLDER="newlib"
-BRANCH_NAME="ee-v4.1.0"
+BRANCH_NAME="ee-v4.3.0"
 if test ! -d "$REPO_FOLDER"; then
   git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
 else


### PR DESCRIPTION
I have been trying to upgrade to the latest newlib available. In this case, `4.3.0`

You can check the changes here:
https://github.com/bminor/newlib/compare/master...ps2dev:newlib:ee-v4.3.0

All the PS2-specific changes are in this small commit:
https://github.com/bminor/newlib/commit/ef5a3dbb7a5282fefa9eb7e2ab7022047b4332d5

The remaining changes are under another commit that autogenerate the content by having proper autoconfig/automake tools after running the command `autoreconf`.

Cheers.