### PR TITLE
Change locking policy to atomic

### DIFF
--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -62,6 +62,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-tls \
     --enable-cxx-flags=-G0 \
     --enable-threads=posix \
+    --with-libstdcxx-lock-policy=atomic \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
Mutexes are a finite resource on the PS2 leading to the ability to quickly exhaust them if e.g. shared_ptr uses one each.