### PR TITLE
Buildsystem improvements

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,42 +13,51 @@ jobs:
     strategy:
       matrix:
         os: [[macos-latest, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+      fail-fast: false
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-    - name: Install Ubuntu texinfo bison flex
+    - name: Install Ubuntu packages
       if: matrix.os[0] == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install texinfo bison flex libgmp3-dev libmpfr-dev libmpc-dev
+        sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev
+        echo "MSYSTEM=x64" >> $GITHUB_ENV
 
-    - name: Install Mac texinfo bison flex
-      if: matrix.os[0] == 'macOS-latest'
+    - name: Install macOS packages
+      if: matrix.os[0] == 'macos-latest'
       run: |
         brew update
-        brew install texinfo bison flex gnu-sed gsl gmp mpfr
+        brew install texinfo bison flex gnu-sed gsl gmp mpfr libmpc
+        echo "MSYSTEM=x64" >> $GITHUB_ENV
 
-    - name: Install MSYS2 texinfo bison flex
+    - name: Install MSYS2 packages
       if: matrix.os[0] == 'windows-latest'
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW32
-        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel
+        install: |
+          base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
+          mingw-w64-i686-cmake mingw-w64-i686-extra-cmake-modules mingw-w64-i686-make mingw-w64-i686-libogg
         update: true
         shell: msys2 {0}
 
     - name: Runs all the stages in the shell
+      continue-on-error: false
       run: |
         export PS2DEV=$PWD/ps2dev
         export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+        export PATH="/usr/local/opt/bison/bin:$PATH"
         export PATH=$PATH:$PS2DEV/ee/bin
         ./toolchain.sh
 
-    - name: Print bins version
+    - name: Print version of executables
       run: |
         export PS2DEV=$PWD/ps2dev
         export PATH=$PATH:$PS2DEV/ee/bin

--- a/config/ps2toolchain-ee-config.sh
+++ b/config/ps2toolchain-ee-config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PS2TOOLCHAIN_EE_BINUTILS_REPO_URL="https://github.com/ps2dev/binutils-gdb.git"
+PS2TOOLCHAIN_EE_BINUTILS_DEFAULT_REPO_REF="ee-v2.38.0"
+PS2TOOLCHAIN_EE_GCC_REPO_URL="https://github.com/ps2dev/gcc.git"
+PS2TOOLCHAIN_EE_GCC_DEFAULT_REPO_REF="ee-v11.3.0"
+PS2TOOLCHAIN_EE_NEWLIB_REPO_URL="https://github.com/ps2dev/newlib.git"
+PS2TOOLCHAIN_EE_NEWLIB_DEFAULT_REPO_REF="ee-v4.3.0"
+PS2TOOLCHAIN_EE_PTHREAD_EMBEDDED_REPO_URL="https://github.com/ps2dev/pthread-embedded.git"
+PS2TOOLCHAIN_EE_PTHREAD_EMBEDDED_DEFAULT_REPO_REF="platform_agnostic"
+
+if test -f "$PS2DEV_CONFIG_OVERRIDE"; then
+  source "$PS2DEV_CONFIG_OVERRIDE"
+fi

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 001-binutils.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 001-binutils.sh by ps2dev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -8,17 +8,28 @@ onerr()
 }
 trap onerr ERR
 
+## Read information from the configuration file.
+source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
+
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/binutils-gdb.git"
-REPO_FOLDER="binutils-gdb"
-BRANCH_NAME="ee-v2.38.0"
+REPO_URL="$PS2TOOLCHAIN_EE_BINUTILS_REPO_URL"
+REPO_REF="$PS2TOOLCHAIN_EE_BINUTILS_DEFAULT_REPO_REF"
+REPO_FOLDER="$(s="$REPO_URL"; s=${s##*/}; printf "%s" "${s%.*}")"
+
+# Checking if a specific Git reference has been passed in parameter $1
+if test -n "$1"; then
+  REPO_REF="$1"
+  printf 'Using specified repo reference %s\n' "$REPO_REF"
+fi
+
 if test ! -d "$REPO_FOLDER"; then
-  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
+  git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$REPO_FOLDER"
 else
   git -C "$REPO_FOLDER" fetch origin
-  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
-  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+  git -C "$REPO_FOLDER" reset --hard "origin/$REPO_REF"
+  git -C "$REPO_FOLDER" checkout "$REPO_REF"
 fi
+
 cd "$REPO_FOLDER"
 
 TARGET_ALIAS="ee"

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 002-gcc-stage1.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 002-gcc-stage1.sh by ps2dev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -8,17 +8,28 @@ onerr()
 }
 trap onerr ERR
 
+## Read information from the configuration file.
+source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
+
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/gcc.git"
-REPO_FOLDER="gcc"
-BRANCH_NAME="ee-v11.3.0"
+REPO_URL="$PS2TOOLCHAIN_EE_GCC_REPO_URL"
+REPO_REF="$PS2TOOLCHAIN_EE_GCC_DEFAULT_REPO_REF"
+REPO_FOLDER="$(s="$REPO_URL"; s=${s##*/}; printf "%s" "${s%.*}")"
+
+# Checking if a specific Git reference has been passed in parameter $1
+if test -n "$1"; then
+  REPO_REF="$1"
+  printf 'Using specified repo reference %s\n' "$REPO_REF"
+fi
+
 if test ! -d "$REPO_FOLDER"; then
-  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
+  git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$REPO_FOLDER"
 else
   git -C "$REPO_FOLDER" fetch origin
-  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
-  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+  git -C "$REPO_FOLDER" reset --hard "origin/$REPO_REF"
+  git -C "$REPO_FOLDER" checkout "$REPO_REF"
 fi
+
 cd "$REPO_FOLDER"
 
 TARGET_ALIAS="ee"

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -70,6 +70,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --without-newlib \
     --disable-libssp \
     --disable-multilib \
+    --disable-nls \
     --disable-tls \
     MAKEINFO=missing \
     $TARG_XTRA_OPTS

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -71,12 +71,13 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-libssp \
     --disable-multilib \
     --disable-tls \
+    MAKEINFO=missing \
     $TARG_XTRA_OPTS
 
   ## Compile and install.
-  make --quiet -j "$PROC_NR" all
-  make --quiet -j "$PROC_NR" install-strip
-  make --quiet -j "$PROC_NR" clean
+  make --quiet -j "$PROC_NR" MAKEINFO=missing all
+  make --quiet -j "$PROC_NR" MAKEINFO=missing install-strip
+  make --quiet -j "$PROC_NR" MAKEINFO=missing clean
 
   ## Exit the build directory.
   cd ..

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 003-newlib.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 003-newlib.sh by ps2dev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -8,17 +8,28 @@ onerr()
 }
 trap onerr ERR
 
+## Read information from the configuration file.
+source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
+
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/newlib.git"
-REPO_FOLDER="newlib"
-BRANCH_NAME="ee-v4.3.0"
+REPO_URL="$PS2TOOLCHAIN_EE_NEWLIB_REPO_URL"
+REPO_REF="$PS2TOOLCHAIN_EE_NEWLIB_DEFAULT_REPO_REF"
+REPO_FOLDER="$(s="$REPO_URL"; s=${s##*/}; printf "%s" "${s%.*}")"
+
+# Checking if a specific Git reference has been passed in parameter $1
+if test -n "$1"; then
+  REPO_REF="$1"
+  printf 'Using specified repo reference %s\n' "$REPO_REF"
+fi
+
 if test ! -d "$REPO_FOLDER"; then
-  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
+  git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$REPO_FOLDER"
 else
   git -C "$REPO_FOLDER" fetch origin
-  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
-  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+  git -C "$REPO_FOLDER" reset --hard "origin/$REPO_REF"
+  git -C "$REPO_FOLDER" checkout "$REPO_REF"
 fi
+
 cd "$REPO_FOLDER"
 
 TARGET_ALIAS="ee"

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 004-newlib-nano.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 004-newlib-nano.sh by ps2dev developers
 
 ## This script is needed to generate a separate and nano libc. This is usefull for such programs that requires to have tiny binaries.
 ## I have tried to use --program-suffix during configure, but it looks that newlib is not using the flag properly.
@@ -12,17 +12,28 @@ onerr()
 }
 trap onerr ERR
 
+## Read information from the configuration file.
+source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
+
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/newlib.git"
-REPO_FOLDER="newlib"
-BRANCH_NAME="ee-v4.3.0"
+REPO_URL="$PS2TOOLCHAIN_EE_NEWLIB_REPO_URL"
+REPO_REF="$PS2TOOLCHAIN_EE_NEWLIB_DEFAULT_REPO_REF"
+REPO_FOLDER="$(s="$REPO_URL"; s=${s##*/}; printf "%s" "${s%.*}")"
+
+# Checking if a specific Git reference has been passed in parameter $1
+if test -n "$1"; then
+  REPO_REF="$1"
+  printf 'Using specified repo reference %s\n' "$REPO_REF"
+fi
+
 if test ! -d "$REPO_FOLDER"; then
-  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
+  git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$REPO_FOLDER"
 else
   git -C "$REPO_FOLDER" fetch origin
-  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
-  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+  git -C "$REPO_FOLDER" reset --hard "origin/$REPO_REF"
+  git -C "$REPO_FOLDER" checkout "$REPO_REF"
 fi
+
 cd "$REPO_FOLDER"
 
 TARGET_ALIAS="ee"

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -70,6 +70,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --with-newlib \
     --disable-libssp \
     --disable-multilib \
+    --disable-nls \
     --disable-tls \
     --enable-cxx-flags=-G0 \
     --enable-threads=posix \

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -73,12 +73,13 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-tls \
     --enable-cxx-flags=-G0 \
     --enable-threads=posix \
+    MAKEINFO=missing \
     $TARG_XTRA_OPTS
 
   ## Compile and install.
-  make --quiet -j "$PROC_NR" all
-  make --quiet -j "$PROC_NR" install-strip
-  make --quiet -j "$PROC_NR" clean
+  make --quiet -j "$PROC_NR" MAKEINFO=missing all
+  make --quiet -j "$PROC_NR" MAKEINFO=missing install-strip
+  make --quiet -j "$PROC_NR" MAKEINFO=missing clean
 
   ## Exit the build directory.
   cd ..

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 006-gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 006-gcc-stage2.sh by ps2dev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -8,17 +8,28 @@ onerr()
 }
 trap onerr ERR
 
+## Read information from the configuration file.
+source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
+
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/gcc.git"
-REPO_FOLDER="gcc"
-BRANCH_NAME="ee-v11.3.0"
+REPO_URL="$PS2TOOLCHAIN_EE_GCC_REPO_URL"
+REPO_REF="$PS2TOOLCHAIN_EE_GCC_DEFAULT_REPO_REF"
+REPO_FOLDER="$(s="$REPO_URL"; s=${s##*/}; printf "%s" "${s%.*}")"
+
+# Checking if a specific Git reference has been passed in parameter $1
+if test -n "$1"; then
+  REPO_REF="$1"
+  printf 'Using specified repo reference %s\n' "$REPO_REF"
+fi
+
 if test ! -d "$REPO_FOLDER"; then
-  git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"  
+  git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$REPO_FOLDER"
 else
   git -C "$REPO_FOLDER" fetch origin
-  git -C "$REPO_FOLDER" reset --hard "origin/${BRANCH_NAME}"
-  git -C "$REPO_FOLDER" checkout "$BRANCH_NAME"
+  git -C "$REPO_FOLDER" reset --hard "origin/$REPO_REF"
+  git -C "$REPO_FOLDER" checkout "$REPO_REF"
 fi
+
 cd "$REPO_FOLDER"
 
 TARGET_ALIAS="ee"

--- a/scripts/007-post-install.sh
+++ b/scripts/007-post-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 007-post-install.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+# 007-post-install.sh by ps2dev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -8,9 +8,8 @@ onerr()
 }
 trap onerr ERR
 
-## Download the source code.
 TARGET_ALIAS="ee"
 TARGET="mips64r5900el-ps2-elf"
 
 # Remove generated dummy crt0.o file
-rm -rf "${PS2DEV}/${TARGET_ALIAS}/${TARGET}/lib/crt0.o"
+rm -rf "$PS2DEV/$TARGET_ALIAS/$TARGET/lib/crt0.o"


### PR DESCRIPTION
Some cleanups and normalization.

The major change is repository URLs and references are now in a separate script to make it easier to update.

This also fixes macOS and Windows builds by disabling texinfo usage.

This also reduces installation size by disabling NLS usage (which was already done in `ps2toolchain-iop`)