### PR TITLE
Build newlib with support for C99 formatters such as %zu.

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -63,6 +63,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --prefix="$PS2DEV/$TARGET_ALIAS" \
     --target="$TARGET" \
     --enable-newlib-retargetable-locking \
+    --enable-newlib-io-c99-formats \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
Submitting this PR to add `--enable-newlib-io-c99-formats` to the default list of configure options, which adds support for C99 formatters such as %zu. This eases the burden of homebrew developers working on ports as they no longer need to change or write special cases to remove `%zu` formatters from their code.

Consider the following sample program:
```c
#include <stdio.h>

int main(void)
{
    printf("Formatter: %zu\n", (size_t)42069);
    return 0;
}
```

Returning the following output:
Before:
```
Formatter: zu
```

After
```
Formatter: 42069
```