### PR TITLE
Enable multithread in newlib

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -63,6 +63,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --prefix="$PS2DEV/$TARGET_ALIAS" \
     --target="$TARGET" \
     --enable-newlib-retargetable-locking \
+    --enable-newlib-multithread \
     --enable-newlib-io-c99-formats \
     $TARG_XTRA_OPTS
 

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -83,6 +83,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --enable-newlib-global-atexit \
     --enable-newlib-nano-formatted-io \
     --enable-newlib-retargetable-locking \
+    --enable-newlib-multithread \
     --disable-nls \
     $TARG_XTRA_OPTS
 


### PR DESCRIPTION
To have thread-safe operations for all the newlib operations we have been required to do several PR:

- [`newlib`](https://github.com/ps2dev/newlib/pull/13)
- [`ps2toolchain-ee`](https://github.com/ps2dev/ps2toolchain-ee/pull/44)
- [`ps2sdk`](https://github.com/ps2dev/ps2sdk/pull/592)

In this PR we just enable the multithreading to be able to use lock API.