### PR TITLE
Updating scripts for AppleSillicon

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -12,11 +12,16 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+        os: [
+          [macos-latest, arm64, bash],
+          [macos-13, x86_64, bash],
+          [ubuntu-latest, x86_64, bash],
+          [windows-latest, x86_64, msys2]
+        ]
       fail-fast: false
     defaults:
      run:
-      shell: ${{ matrix.os[1] }} {0}
+      shell: ${{ matrix.os[2] }} {0}
 
     steps:
     - uses: actions/checkout@v4
@@ -28,7 +33,7 @@ jobs:
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev
 
     - name: Install macOS packages
-      if: matrix.os[0] == 'macos-latest'
+      if: startsWith(matrix.os[0], 'macos')
       run: |
         brew update
         brew install texinfo bison flex gnu-sed gsl gmp mpfr libmpc
@@ -46,8 +51,7 @@ jobs:
     - name: Runs all the stages in the shell
       run: |
         export PS2DEV=$PWD/ps2dev
-        export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
-        export PATH="/usr/local/opt/bison/bin:$PATH"
+        export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH" # This is just needed for MacOS
         export PATH=$PATH:$PS2DEV/ee/bin
         ./toolchain.sh
 

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -36,14 +36,17 @@ TARGET_ALIAS="ee"
 TARG_XTRA_OPTS=""
 OSVER=$(uname)
 
-if [ "${OSVER:0:10}" == MINGW64_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=x86_64-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=x86_64-w64-mingw32"
-elif [ "${OSVER:0:10}" == MINGW32_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=i686-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=i686-w64-mingw32"
+## If using MacOS Apple, set gmp and mpfr paths using TARG_XTRA_OPTS 
+## (this is needed for Apple Silicon but we will do it for all MacOS systems)
+if [ "$(uname -s)" = "Darwin" ]; then
+  ## Check if using brew
+  if command -v brew &> /dev/null; then
+    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr)"
+  fi
+  ## Check if using MacPorts
+  if command -v port &> /dev/null; then
+    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr)"
+  fi
 fi
 
 ## Determine the maximum number of processes that Make can work with.

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -37,16 +37,6 @@ TARG_XTRA_OPTS=""
 TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
 OSVER=$(uname)
 
-if [ "${OSVER:0:10}" == MINGW64_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=x86_64-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=x86_64-w64-mingw32"
-elif [ "${OSVER:0:10}" == MINGW32_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=i686-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=i686-w64-mingw32"
-fi
-
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -41,16 +41,6 @@ TARG_XTRA_OPTS=""
 TARGET_CFLAGS="-DPREFER_SIZE_OVER_SPEED=1 -Os -gdwarf-2 -gz"
 OSVER=$(uname)
 
-if [ "${OSVER:0:10}" == MINGW64_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=x86_64-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=x86_64-w64-mingw32"
-elif [ "${OSVER:0:10}" == MINGW32_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=i686-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=i686-w64-mingw32"
-fi
-
 PS2DEV_TMP="$PWD/ps2dev-tmp"
 
 ## Create ps2dev-tmp folder

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -37,17 +37,17 @@ TARG_XTRA_OPTS=""
 TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
 OSVER=$(uname)
 
-# Workaround to build with newer mingw-w64 https://github.com/msys2/MINGW-packages/commit/4360ed1a7470728be1dba0687df764604f1992d9
-if [ "${OSVER:0:10}" == MINGW64_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=x86_64-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=x86_64-w64-mingw32"
-  export CPPFLAGS="-DWIN32_LEAN_AND_MEAN -DCOM_NO_WINDOWS_H"
-elif [ "${OSVER:0:10}" == MINGW32_NT ]; then
-  export lt_cv_sys_max_cmd_len=8000
-  export CC=i686-w64-mingw32-gcc
-  TARG_XTRA_OPTS="--host=i686-w64-mingw32"
-  export CPPFLAGS="-DWIN32_LEAN_AND_MEAN -DCOM_NO_WINDOWS_H"
+## If using MacOS Apple, set gmp, mpfr and mpc paths using TARG_XTRA_OPTS 
+## (this is needed for Apple Silicon but we will do it for all MacOS systems)
+if [ "$(uname -s)" = "Darwin" ]; then
+  ## Check if using brew
+  if command -v brew &> /dev/null; then
+    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc)"
+  fi
+  ## Check if using MacPorts
+  if command -v port &> /dev/null; then
+    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-mpc=$(port -q prefix libmpc)"
+  fi
 fi
 
 ## Determine the maximum number of processes that Make can work with.
@@ -77,13 +77,12 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-tls \
     --enable-cxx-flags=-G0 \
     --enable-threads=posix \
-    MAKEINFO=missing \
     $TARG_XTRA_OPTS
 
   ## Compile and install.
-  make --quiet -j "$PROC_NR" MAKEINFO=missing all
-  make --quiet -j "$PROC_NR" MAKEINFO=missing install-strip
-  make --quiet -j "$PROC_NR" MAKEINFO=missing clean
+  make --quiet -j "$PROC_NR" all
+  make --quiet -j "$PROC_NR" install-strip
+  make --quiet -j "$PROC_NR" clean
 
   ## Exit the build directory.
   cd ..


### PR DESCRIPTION
## Description

This PRs is making `ps2toolchain-ee` to be compatible with new `MacOS` Apple Sillicon computers (ARM M1/M2...)

Major changes:
- Binutils keeps being 2.41 (2.42 wasn't compiling and I couldn't find the proper commit to cherry-pick), however, a cherry-pick has been needed too:
  - https://github.com/ps2dev/binutils-gdb/commit/cecb761ff528752c0d070324f2d31e34e6ef6a2e
- GCC keeps on 13.2.0, however, another 2 cherry picks have been done:
  - https://github.com/ps2dev/gcc/commit/de1429bb2ae614dd282bb2686fb499b1e3a58e78
  - https://github.com/ps2dev/gcc/commit/2efd9b990245c939567bb4021b95a9eba3c1a3f8
- Update scripts running now `prefix` calls to find out the specific folders for dependencies for brew and port (not tested)
- Workflow now execute `macos-13` for Intel and `macos-latest` for ARM (currently there is no way of using `macos-latest` for Intel)
- Some minor cleanups

Cheers