### PR TITLE
Avoid mixing content from GCC stage 1 and stage 2

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -8,6 +8,20 @@ onerr()
 }
 trap onerr ERR
 
+TARGET_ALIAS="ee"
+TARG_XTRA_OPTS=""
+TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
+OSVER=$(uname)
+
+## Create a temporal folder where to build the phase 1 of the toolchain.
+TMP_TOOLCHAIN_BUILD_DIR=$(pwd)/tmp_toolchain_build
+rm -rf "${TMP_TOOLCHAIN_BUILD_DIR}" && mkdir "${TMP_TOOLCHAIN_BUILD_DIR}"
+## Copy toolchain content ($PS2DEV) to the temporal folder.
+cp -r "${PS2DEV}/" "${TMP_TOOLCHAIN_BUILD_DIR}"
+
+## Add the toolchain to the PATH.
+export PATH="$TMP_TOOLCHAIN_BUILD_DIR/$TARGET_ALIAS/bin:$PATH"
+
 ## Read information from the configuration file.
 source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
 
@@ -31,11 +45,6 @@ else
 fi
 
 cd "$REPO_FOLDER"
-
-TARGET_ALIAS="ee"
-TARG_XTRA_OPTS=""
-TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
-OSVER=$(uname)
 
 ## If using MacOS Apple, set gmp, mpfr and mpc paths using TARG_XTRA_OPTS 
 ## (this is needed for Apple Silicon but we will do it for all MacOS systems)
@@ -65,7 +74,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
   CFLAGS_FOR_TARGET="$TARGET_CFLAGS" \
   ../configure \
     --quiet \
-    --prefix="$PS2DEV/$TARGET_ALIAS" \
+    --prefix="$TMP_TOOLCHAIN_BUILD_DIR/$TARGET_ALIAS" \
     --target="$TARGET" \
     --enable-languages="c" \
     --with-float=hard \

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -8,6 +8,16 @@ onerr()
 }
 trap onerr ERR
 
+TARGET_ALIAS="ee"
+TARG_XTRA_OPTS=""
+TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
+OSVER=$(uname)
+
+## Create a temporal folder where to build the phase 1 of the toolchain.
+TMP_TOOLCHAIN_BUILD_DIR=$(pwd)/tmp_toolchain_build
+## Add the toolchain to the PATH.
+export PATH="$TMP_TOOLCHAIN_BUILD_DIR/$TARGET_ALIAS/bin:$PATH"
+
 ## Read information from the configuration file.
 source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
 
@@ -31,11 +41,6 @@ else
 fi
 
 cd "$REPO_FOLDER"
-
-TARGET_ALIAS="ee"
-TARG_XTRA_OPTS=""
-TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
-OSVER=$(uname)
 
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
@@ -67,3 +72,6 @@ for TARGET in "mips64r5900el-ps2-elf"; do
 
   ## End target.
 done
+
+## Copy contents of the toolchain to the temporal folder.
+cp -r "${PS2DEV}/" "${TMP_TOOLCHAIN_BUILD_DIR}"

--- a/scripts/005-pthread-embedded.sh
+++ b/scripts/005-pthread-embedded.sh
@@ -8,6 +8,15 @@ onerr()
 }
 trap onerr ERR
 
+TARGET_ALIAS="ee"
+TARG_XTRA_OPTS=""
+OSVER=$(uname)
+
+## Temporal folder where to build the phase 1 of the toolchain.
+TMP_TOOLCHAIN_BUILD_DIR=$(pwd)/tmp_toolchain_build
+## Add the toolchain to the PATH.
+export PATH="$TMP_TOOLCHAIN_BUILD_DIR/$TARGET_ALIAS/bin:$PATH"
+
 ## Read information from the configuration file.
 source "$(dirname "$0")/../config/ps2toolchain-ee-config.sh"
 
@@ -31,10 +40,6 @@ else
 fi
 
 cd "$REPO_FOLDER"
-
-TARGET_ALIAS="ee"
-TARG_XTRA_OPTS=""
-OSVER=$(uname)
 
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
## Description
I was trying to compile https://github.com/google/googletest for PSP and I was facing some errors when finding the `MAX_PATH` macro.

In theory the content of `MAX_PATH` is in the `limits.h` header, coming from `newlib`, however, `googletest` even including `limits.h` wasn't finding the `MAX_PATH` variable.
This was happening because we had conflicts with headers.
```
ps2dev/ee/lib/gcc/mips64r5900el-ps2-elf/14.1.0/include/limits.h
```

```
ps2dev/ee/mips64r5900el-ps2-elf/include/limits.h
```

The very first one, was the file being used when compiling `googletest`, this file shouldn't exist in our toolchain, however, the file is installed afer compiling `gcc` stage 1.

This is why I have created this PR.
The main scope of this PR is to be sure that GCC stage 1 content is shipped to a temporal folder, trying to avoid mixing it with the final content.

Additionally, other minor changes have been made.

Maybe there is a cleaner and smarter way to do this, but I couldn't find anything better.

Cheers