### PR TITLE
Enable libatomic support

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -73,13 +73,14 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --without-newlib \
     --disable-libssp \
     --disable-multilib \
+    --disable-libatomic \
     --disable-nls \
     --disable-tls \
     $TARG_XTRA_OPTS
 
   ## Compile and install.
-  make --quiet -j "$PROC_NR" all
-  make --quiet -j "$PROC_NR" install-strip
+  make --quiet -j "$PROC_NR" all-gcc
+  make --quiet -j "$PROC_NR" install-gcc
   make --quiet -j "$PROC_NR" clean
 
   ## Exit the build directory.


### PR DESCRIPTION
This PR sped up the GCC phase 1, compiling just needed stuff.
Then additionally thanks to https://github.com/ps2dev/gcc/pull/10 we will have atomic support.

Cheers.