### PR TITLE
Fix header conflict

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -63,6 +63,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --quiet \
     --prefix="$PS2DEV/$TARGET_ALIAS" \
     --target="$TARGET" \
+    --with-sysroot="$PS2DEV/$TARGET_ALIAS/$TARGET" \
     --disable-separate-code \
     --disable-sim \
     --disable-nls \

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -71,11 +71,17 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --with-float=hard \
     --without-headers \
     --without-newlib \
-    --disable-libssp \
+    --disable-libgcc \
+    --disable-shared \
+    --disable-threads \
     --disable-multilib \
     --disable-libatomic \
     --disable-nls \
     --disable-tls \
+    --disable-libssp \
+    --disable-libgomp \
+    --disable-libmudflap \
+    --disable-libquadmath \
     $TARG_XTRA_OPTS
 
   ## Compile and install.

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -52,6 +52,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
   ../configure \
     --prefix="$PS2DEV/$TARGET_ALIAS" \
     --target="$TARGET" \
+    --with-sysroot="$PS2DEV/$TARGET_ALIAS/$TARGET" \
     --enable-newlib-retargetable-locking \
     --enable-newlib-multithread \
     --enable-newlib-io-c99-formats \

--- a/scripts/004-newlib-nano.sh
+++ b/scripts/004-newlib-nano.sh
@@ -62,6 +62,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
   ../configure \
     --prefix="$PS2DEV_TMP/$TARGET_ALIAS" \
     --target="$TARGET" \
+    --with-sysroot="$PS2DEV/$TARGET_ALIAS/$TARGET" \
     --disable-newlib-supplied-syscalls \
     --enable-newlib-reent-small \
     --disable-newlib-fvwrite-in-streamio \

--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -71,6 +71,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --enable-languages="c,c++" \
     --with-float=hard \
     --with-sysroot="$PS2DEV/$TARGET_ALIAS/$TARGET" \
+    --with-native-system-header-dir="/include" \
     --with-newlib \
     --disable-libssp \
     --disable-multilib \


### PR DESCRIPTION
## Description

I was trying to compile https://github.com/google/googletest for PS2 and I was facing some errors when finding the MAX_PATH macro.

Then I faced that the generated header files for GCC step 2 they weren't generated properly.
Afther some days of investigation I have been able to find out where the issue was, we missed the usage of `sysroot` and `native-system-header-dir`

I have made also some clean up in the scripts:
- Reduce GCC phase 1 compilation
- Other minor changes.

Once merged I will add `googletest` as a dependency in `ps2sdk-ports` in this way we could at least notice in the future similar issues.

This PR deprecates the previous one https://github.com/ps2dev/ps2toolchain-ee/pull/47

Cheers.