### PR TITLE
workaround: build gdb without python

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -67,6 +67,7 @@ for TARGET in "mips64r5900el-ps2-elf"; do
     --disable-separate-code \
     --disable-sim \
     --disable-nls \
+    --with-python=no \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
For those people that have newer python installed with missing `PySys_SetPath` API