### PR TITLE
Add GNU sed fallback for macOS to support GCC build

### DIFF
--- a/scripts/006-gcc-stage2.sh
+++ b/scripts/006-gcc-stage2.sh
@@ -42,11 +42,13 @@ OSVER=$(uname)
 if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
+    export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"
     TARG_XTRA_OPTS="--with-system-zlib --with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc)"
   elif command -v port &> /dev/null; then
   ## Check if using MacPorts
     MACPORT_BASE=$(dirname `port -q contents gmp|grep gmp.h`|sed s#/include##g)
     echo Macport base is $MACPORT_BASE
+    alias sed='gsed'
     TARG_XTRA_OPTS="--with-system-zlib --with-gmp=$MACPORT_BASE --with-mpfr=$MACPORT_BASE --with-mpc=$MACPORT_BASE"
   fi
 fi


### PR DESCRIPTION
This PR adds support for GNU sed on macOS to ensure compatibility when compiling GCC. By default, macOS ships with BSD sed, which lacks several GNU extensions required by the build scripts.